### PR TITLE
Use Poison atom keys

### DIFF
--- a/examples/simple_blog/mix.lock
+++ b/examples/simple_blog/mix.lock
@@ -2,7 +2,6 @@
   "certifi": {:hex, :certifi, "0.4.0", "a7966efb868b179023618d29a407548f70c52466bf1849b9e8ebd0e34b7ea11f", [:rebar3], []},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
-  "crutches": {:hex, :crutches, "1.0.0", "34675f0c88f25a3a6d2a77912194beaece9bf835f9f2f5627027b4a19125aaa6", [:mix], []},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},
   "hackney": {:hex, :hackney, "1.6.0", "8d1e9440c9edf23bf5e5e2fe0c71de03eb265103b72901337394c840eec679ac", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},

--- a/lib/dayron/adapters/httpoison_adapter.ex
+++ b/lib/dayron/adapters/httpoison_adapter.ex
@@ -17,7 +17,6 @@ defmodule Dayron.HTTPoisonAdapter do
     json responses to Maps or a List of Maps. Maps keys are also converted to
     atoms by default.
     """
-    require Crutches
     require Poison
     use HTTPoison.Base
 
@@ -28,20 +27,10 @@ defmodule Dayron.HTTPoisonAdapter do
 
     def process_response_body(body) do
       try do
-        body |> Poison.decode! |> process_decoded_body
+        body |> Poison.decode!(keys: :atoms)
       rescue
         Poison.SyntaxError -> body
       end
-    end
-
-    defp process_decoded_body(body) when is_list(body) do
-      body |> Enum.map(&process_decoded_body(&1))
-    end
-
-    defp process_decoded_body(body) do
-      body
-      |> Enum.into(%{})
-      |> Crutches.Map.dkeys_update(fn (key) -> String.to_atom(key) end)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Dayron.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :httpoison, :crutches]]
+    [applications: [:logger, :httpoison]]
   end
 
   # Dependencies can be Hex packages:
@@ -45,7 +45,6 @@ defmodule Dayron.Mixfile do
     [
       {:poison,       "~> 1.5 or ~> 2.0"},
       {:httpoison,    "~> 0.8.0"},
-      {:crutches,     "~> 1.0.0"},
       {:credo,        "~> 0.3",     only: [:dev, :test]},
       {:bypass,       "~> 0.1",     only: :test},
       {:excoveralls,  "~> 0.5",     only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,6 @@
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "credo": {:hex, :credo, "0.3.13", "90d2d2deb9d376bb2a63f81126a320c3920ce65acb1294982ab49a8aacc7d89f", [:mix], [{:bunt, "~> 0.1.4", [hex: :bunt, optional: false]}]},
-  "crutches": {:hex, :crutches, "1.0.0", "34675f0c88f25a3a6d2a77912194beaece9bf835f9f2f5627027b4a19125aaa6", [:mix], []},
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "excoveralls": {:hex, :excoveralls, "0.5.4", "1a6e116bcf980da8b7fe33140c1d7e61aa0a4e51951cadbfacc420c12d2b9b8f", [:mix], [{:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}, {:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}]},


### PR DESCRIPTION
Instead of manually converting JSON keys to atoms in `Dayron.HTTPoisonAdapter`, eliminate a dependency and some code by using the `keys: :atoms` option for Poison when decoding.