### PR TITLE
Allow overriding __from_json_list__/2 in Model

### DIFF
--- a/lib/dayron/model.ex
+++ b/lib/dayron/model.ex
@@ -93,7 +93,7 @@ defmodule Dayron.Model do
 
       def __from_json_list__(data, _opts), do: struct(__MODULE__, data)
 
-      defoverridable [__url_for__: 1, __from_json__: 2]
+      defoverridable [__url_for__: 1, __from_json__: 2, __from_json_list__: 2]
     end
   end
 


### PR DESCRIPTION
This allows overriding the root-level key in the json response for scenarios where the array of records is nested inside of an attribute, such as `data`.